### PR TITLE
Update to use forked solidus_frontend when needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,13 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+solidus_git, solidus_frontend_git = if (branch == 'master') || (branch >= 'v3.2')
+                                      %w[solidusio/solidus solidusio/solidus_frontend]
+                                    else
+                                      %w[solidusio/solidus] * 2
+                                    end
+gem 'solidus', github: solidus_git, branch: branch
+gem 'solidus_frontend', github: solidus_frontend_git, branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -10,7 +10,7 @@ module SolidusPaypalCommercePlatform
       authorize! :create, ::Spree::Order
 
       @order = ::Spree::Order.create!(
-        user: try_spree_current_user,
+        user: ::Spree.solidus_gem_version >= Gem::Version.new('3.2') ? spree_current_user : try_spree_current_user,
         store: current_store,
         currency: current_pricing_options.currency
       )

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusPaypalCommercePlatform
-  class PaymentMethod < SolidusSupport.payment_method_parent_class
+  class PaymentMethod < ::Spree::PaymentMethod
     include SolidusPaypalCommercePlatform::ButtonOptionsHelper
     preference :client_id, :string
     preference :client_secret, :string

--- a/app/models/solidus_paypal_commerce_platform/payment_source.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusPaypalCommercePlatform
-  class PaymentSource < SolidusSupport.payment_source_parent_class
+  class PaymentSource < ::Spree::PaymentSource
     self.table_name = "paypal_commerce_platform_sources"
     enum paypal_funding_source: {
       applepay: 0, bancontact: 1, blik: 2, boleto: 3, card: 4, credit: 5, eps: 6, giropay: 7, ideal: 8,

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/releases'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('> 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe "Cart page" do
     before do
       user = create(:user)
       order.user = user
+      visit spree.root_path
+      click_link 'Login'
+  
+      fill_in 'spree_user[email]', with: user.email
+      fill_in 'spree_user[password]', with: 'secret'
+      click_button 'Login'
 
       paypal_payment_method
       allow_any_instance_of(Spree::OrdersController).to receive_messages(
@@ -37,6 +43,7 @@ RSpec.describe "Cart page" do
         it "generates a url with intent capture" do
           paypal_payment_method.update(auto_capture: true)
           visit '/cart'
+          
           expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
           expect(js_sdk_script_query).to include("intent=capture")
         end

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe "Checkout" do
 
     before do
       user = create(:user)
+      visit spree.root_path
+      click_link 'Login'  
+      fill_in 'spree_user[email]', with: user.email
+      fill_in 'spree_user[password]', with: 'secret'
+      click_button 'Login'
       order.user = user
       order.recalculate
 


### PR DESCRIPTION
Update to a recent version of the gem, but before the internalization of the Paypal SDK, to fix an error where the bearer token header wasn't getting added to Paypal requests, causing the Paypal button to error out.